### PR TITLE
fix: add count to the data block

### DIFF
--- a/examples/apply_taints/README.md
+++ b/examples/apply_taints/README.md
@@ -2,3 +2,82 @@
 
  - This example provisions OCP cluster and set taints for worker pools.
  - The example also enables a key protect provider for the cluster, as well as the required COS instance.
+ - The OCP cluster created has a private endpoint.
+
+ ## Private Cluster
+
+ ## Usage
+```hcl
+# Replace "master" with a GIT release version to lock into a specific release
+module "ocp_base" {
+  # update this value to the value of your IBM Cloud API key
+  ibmcloud_api_key     = "ibm cloud api key" # pragma: allowlist secret
+  source = "git::https://github.com/terraform-ibm-modules/terraform-ibm-base-ocp-vpc.git?ref=master"
+  cluster_name         = "example-cluster-name"
+  # modify the value for resource_group_id with and id of a group you own
+  resource_group_id    = "id of existing resource group"
+  region               = "us-south"
+  force_delete_storage = true
+  vpc_id               = "id of existing VPC"
+  ## obtain the below values from the targeted VPC and adjust to the number of zones,
+  ## subnets, subnet name, cidr_block, id, zone
+  vpc_subnets          = {
+    zone-1    = [
+        {
+            cidr_block = "192.168.32.0/22"
+            id         = "0717-afc29fbb-0dbe-493a-a5b9-f3c5899cb8b9"
+            zone       = "us-south-1"
+        },
+        {
+            cidr_block = "192.168.36.0/22"
+            id         = "0727-d65c1eda-9e38-4200-8452-cb8ff5bb3140"
+            zone       = "us-south-2"
+        },
+        {
+            cidr_block = "192.168.40.0/22"
+            id         = "0737-9a823cd3-16bf-4ba4-a429-9e1fc7db74b8"
+            zone       = "us-south-3"
+        }
+    ]
+    zone-2 = [
+        {
+            cidr_block = "192.168.0.0/22"
+            id         = "0717-846b9490-34ae-4a6c-8288-28112dca1ba3"
+            zone       = "us-south-1"
+        },
+        {
+            cidr_block = "192.168.4.0/22"
+            id         = "0727-ef8db7f6-ffa5-4d8b-a317-4631741a45ee"
+            zone       = "us-south-2"
+        },
+        {
+            cidr_block = "192.168.8.0/22"
+            id         = "0737-c9a6d871-d95b-4914-abf5-82c22f4161d1"
+            zone       = "us-south-3"
+        }
+    ]
+    zone-3 = [
+        {
+            cidr_block = "192.168.16.0/22"
+            id         = "0717-d46e227c-89d4-4b02-9008-d03907a275b6"
+            zone       = "us-south-1"
+        },
+        {
+            cidr_block = "192.168.20.0/22"
+            id         = "0727-93b1edcb-966c-4517-a7af-6ac63cd93adf"
+            zone       = "us-south-2"
+        },
+        {
+            cidr_block = "192.168.24.0/22"
+            id         = "0737-807ec4f1-4d84-484e-b2f4-62dd5e431065"
+            zone       = "us-south-3"
+        }
+    ]
+  }
+  disable_public_endpoint         = true
+  ## verify_worker_network_readiness should be set to false when runtime does not have access to the kube-api-server.
+  ## For example, if we are running terraform apply from a vsi server which is connected to the cluster vpc using a vpn or transit gateway that time verify_worker_network_readiness can be set to true.
+  verify_worker_network_readiness = false
+}
+
+```

--- a/examples/apply_taints/main.tf
+++ b/examples/apply_taints/main.tf
@@ -62,18 +62,20 @@ locals {
 }
 
 module "ocp_base" {
-  source               = "../.."
-  cluster_name         = var.prefix
-  ibmcloud_api_key     = var.ibmcloud_api_key
-  resource_group_id    = module.resource_group.resource_group_id
-  region               = var.region
-  force_delete_storage = true
-  vpc_id               = module.vpc.vpc_id
-  vpc_subnets          = local.cluster_vpc_subnets
-  worker_pools         = var.worker_pools
-  worker_pools_taints  = var.worker_pools_taints
-  ocp_version          = var.ocp_version
-  tags                 = var.resource_tags
+  source                          = "../.."
+  cluster_name                    = var.prefix
+  ibmcloud_api_key                = var.ibmcloud_api_key
+  resource_group_id               = module.resource_group.resource_group_id
+  region                          = var.region
+  force_delete_storage            = true
+  vpc_id                          = module.vpc.vpc_id
+  vpc_subnets                     = local.cluster_vpc_subnets
+  worker_pools                    = var.worker_pools
+  worker_pools_taints             = var.worker_pools_taints
+  ocp_version                     = var.ocp_version
+  disable_public_endpoint         = var.disable_public_endpoint
+  verify_worker_network_readiness = var.verify_worker_network_readiness
+  tags                            = var.resource_tags
   kms_config = {
     instance_id = module.kp_all_inclusive.key_protect_guid
     crk_id      = module.kp_all_inclusive.keys["ocp.${var.prefix}-cluster-key"].key_id

--- a/examples/apply_taints/variables.tf
+++ b/examples/apply_taints/variables.tf
@@ -185,4 +185,16 @@ variable "worker_pools_taints" {
   }
 }
 
+variable "disable_public_endpoint" {
+  type        = bool
+  description = "Flag indicating that the public endpoint should be enabled or disabled"
+  default     = true
+}
+
+variable "verify_worker_network_readiness" {
+  type        = bool
+  description = "By setting this to true, a script will run kubectl commands to verify that all worker nodes can communicate successfully with the master. If the runtime does not have access to the kube cluster to run kubectl commands, this should be set to false."
+  default     = false
+}
+
 ##############################################################################

--- a/main.tf
+++ b/main.tf
@@ -199,6 +199,7 @@ resource "null_resource" "reset_api_key" {
 ##############################################################################
 
 data "ibm_container_cluster_config" "cluster_config" {
+  count             = var.verify_worker_network_readiness ? 1 : 0
   cluster_name_id   = local.cluster_id
   config_dir        = "${path.module}/kubeconfig"
   resource_group_id = var.resource_group_id
@@ -319,7 +320,7 @@ resource "null_resource" "confirm_network_healthy" {
     command     = "${path.module}/scripts/confirm_network_healthy.sh"
     interpreter = ["/bin/bash", "-c"]
     environment = {
-      KUBECONFIG = data.ibm_container_cluster_config.cluster_config.config_file_path
+      KUBECONFIG = data.ibm_container_cluster_config.cluster_config[0].config_file_path
     }
   }
 }

--- a/module-metadata.json
+++ b/module-metadata.json
@@ -207,6 +207,7 @@
       "description": "By setting this to true, a script will run kubectl commands to verify that all worker nodes can communicate successfully with the master. If the runtime does not have access to the kube cluster to run kubectl commands, this should be set to false.",
       "default": true,
       "source": [
+        "data.ibm_container_cluster_config.cluster_config.count",
         "null_resource.confirm_network_healthy.count"
       ],
       "pos": {
@@ -456,7 +457,7 @@
       },
       "pos": {
         "filename": "main.tf",
-        "line": 252
+        "line": 253
       }
     },
     "ibm_container_vpc_worker_pool.pool": {
@@ -472,7 +473,7 @@
       },
       "pos": {
         "filename": "main.tf",
-        "line": 211
+        "line": 212
       }
     },
     "ibm_resource_instance.cos_instance": {
@@ -503,7 +504,7 @@
       },
       "pos": {
         "filename": "main.tf",
-        "line": 312
+        "line": 313
       }
     },
     "null_resource.reset_api_key": {
@@ -525,6 +526,7 @@
       "type": "ibm_container_cluster_config",
       "name": "cluster_config",
       "attributes": {
+        "count": "verify_worker_network_readiness",
         "resource_group_id": "resource_group_id"
       },
       "provider": {


### PR DESCRIPTION
### Description

Added a count = var.verify_worker_network_readiness ? 1 : 0 on that data block and creating a private-only cluster in the apply_taints example which runs a test in the other_tests.
Ref: https://github.com/terraform-ibm-modules/terraform-ibm-base-ocp-vpc/pull/68#issuecomment-1479910490

### Types of changes in this PR

#### No release required

- [ ] Examples or tests (addition or updates of examples or tests)
- [ ] Documentation update
- [ ] CI-related update (pipeline, etc.)
- [ ] Other changes that don't affect Terraform code

#### Release required

- [x] Bug fix (patch release (`x.x.X`): Change that fixes an issue and is compatible with earlier versions)
- [ ] New feature (minor release (`x.X.x`): Change that adds functionality and is compatible with earlier versions)
- [ ] Breaking change (major release (`X.x.x`): Change that is likely incompatible with previous versions)

##### Release notes content

Replace this text with information that users need to know about the bug fixes, features, and breaking changes. This information helps the merger write the commit message that is published in the release notes for the module.

---

### Checklist for reviewers

- [x] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### Merge actions for mergers

- Merge by using "Squash and merge".
- Use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents and any release notes provided by the PR author.

    The commit message determines whether a new version of the module is needed, and if so, which semver increment to use (major, minor, or patch).
