### PR TITLE
feat: added region and res group id when collecting available versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,4 @@ Brewfile.lock.json
 
 # VS Code State
 .vscode/
+*.code-workspace

--- a/cra-tf-validate-ignore-goals.json
+++ b/cra-tf-validate-ignore-goals.json
@@ -13,6 +13,24 @@
             "is_valid": true
         },
         {
+            "scc_goal_id": "3000802",
+            "description:": "Check whether Kubernetes Service is accessible only by using private endpoints",
+            "ignore_reason": "This is a valid issue (same as 3000902) - tracking in https://github.ibm.com/GoldenEye/issues/issues/174",
+            "is_valid": true
+        },
+        {
+            "scc_goal_id": "3000805",
+            "description:": "Check whether Kubernetes Service clusters are enabled with IBM Log Analysis",
+            "ignore_reason": "False alarm. In order to have more control over the way observability agents are configured and deployed, a helm chart installation is used rather than the native provider support.",
+            "is_valid": false
+        },
+        {
+            "scc_goal_id": "3000804",
+            "description:": "Check whether Kubernetes Service clusters are enabled with IBM Cloud Monitoring",
+            "ignore_reason": "False alarm. In order to have more control over the way observability agents are configured and deployed, a helm chart installation is used rather than the native provider support.",
+            "is_valid": false
+        },
+        {
             "scc_goal_id": "3000258",
             "description": "Check whether Cloud Object Storage has at least # users with the IAM manager role",
             "ignore_reason": "Tracking in https://github.ibm.com/GoldenEye/issues/issues/3905",

--- a/main.tf
+++ b/main.tf
@@ -32,7 +32,10 @@ locals {
 }
 
 # Lookup the current default kube version
-data "ibm_container_cluster_versions" "cluster_versions" {}
+data "ibm_container_cluster_versions" "cluster_versions" {
+  resource_group_id = var.resource_group_id
+  region            = var.region
+}
 
 resource "ibm_resource_instance" "cos_instance" {
   count = var.use_existing_cos ? 0 : 1

--- a/module-metadata.json
+++ b/module-metadata.json
@@ -165,10 +165,15 @@
       "type": "string",
       "description": "The IBM Cloud region where the cluster will be provisioned.",
       "required": true,
+      "source": [
+        "data.ibm_container_cluster_versions.cluster_versions.region"
+      ],
       "pos": {
         "filename": "variables.tf",
         "line": 17
-      }
+      },
+      "cloud_data_type": "region",
+      "deprecated": "This field is deprecated"
     },
     "resource_group_id": {
       "name": "resource_group_id",
@@ -177,6 +182,7 @@
       "required": true,
       "source": [
         "data.ibm_container_cluster_config.cluster_config.resource_group_id",
+        "data.ibm_container_cluster_versions.cluster_versions.resource_group_id",
         "ibm_container_vpc_cluster.autoscaling_cluster.resource_group_id",
         "ibm_container_vpc_cluster.cluster.resource_group_id",
         "ibm_container_vpc_worker_pool.autoscaling_pool.resource_group_id",
@@ -363,7 +369,8 @@
         "filename": "outputs.tf",
         "line": 43
       },
-      "type": "string"
+      "type": "string",
+      "cloud_data_type": "region"
     },
     "resource_group_id": {
       "name": "resource_group_id",
@@ -427,7 +434,7 @@
       },
       "pos": {
         "filename": "main.tf",
-        "line": 120
+        "line": 123
       }
     },
     "ibm_container_vpc_cluster.cluster": {
@@ -450,7 +457,7 @@
       },
       "pos": {
         "filename": "main.tf",
-        "line": 58
+        "line": 61
       }
     },
     "ibm_container_vpc_worker_pool.autoscaling_pool": {
@@ -466,7 +473,7 @@
       },
       "pos": {
         "filename": "main.tf",
-        "line": 271
+        "line": 274
       }
     },
     "ibm_container_vpc_worker_pool.pool": {
@@ -482,7 +489,7 @@
       },
       "pos": {
         "filename": "main.tf",
-        "line": 230
+        "line": 233
       }
     },
     "ibm_resource_instance.cos_instance": {
@@ -498,7 +505,7 @@
       },
       "pos": {
         "filename": "main.tf",
-        "line": 37
+        "line": 40
       }
     },
     "ibm_resource_tag.cluster_access_tag": {
@@ -515,7 +522,7 @@
       },
       "pos": {
         "filename": "main.tf",
-        "line": 184
+        "line": 187
       }
     },
     "ibm_resource_tag.cos_access_tag": {
@@ -531,7 +538,7 @@
       },
       "pos": {
         "filename": "main.tf",
-        "line": 47
+        "line": 50
       }
     },
     "null_resource.confirm_network_healthy": {
@@ -546,7 +553,7 @@
       },
       "pos": {
         "filename": "main.tf",
-        "line": 331
+        "line": 334
       }
     },
     "null_resource.reset_api_key": {
@@ -558,7 +565,7 @@
       },
       "pos": {
         "filename": "main.tf",
-        "line": 205
+        "line": 208
       }
     }
   },
@@ -576,13 +583,17 @@
       },
       "pos": {
         "filename": "main.tf",
-        "line": 219
+        "line": 222
       }
     },
     "data.ibm_container_cluster_versions.cluster_versions": {
       "mode": "data",
       "type": "ibm_container_cluster_versions",
       "name": "cluster_versions",
+      "attributes": {
+        "region": "region",
+        "resource_group_id": "resource_group_id"
+      },
       "provider": {
         "name": "ibm"
       },


### PR DESCRIPTION
### Description

In order to retrieve coherent information from IKS API about available versions within the same region where the cluster is going to be created the ibm_container_cluster_versions data source is now using the region 
In addiction I added the resource group id as it is expected to reduce the response time on IKS API according to the API specs.

https://github.com/terraform-ibm-modules/terraform-ibm-base-ocp-vpc/issues/159

### Types of changes in this PR

#### No release required

- [ ] Examples or tests (addition or updates of examples or tests)
- [ ] Documentation update
- [ ] CI-related update (pipeline, etc.)
- [ ] Other changes that don't affect Terraform code

#### Release required

- [X] Bug fix (patch release (`x.x.X`): Change that fixes an issue and is compatible with earlier versions)
- [ ] New feature (minor release (`x.X.x`): Change that adds functionality and is compatible with earlier versions)
- [ ] Breaking change (major release (`X.x.x`): Change that is likely incompatible with previous versions)

##### Release notes content

More info available at (https://github.com/terraform-ibm-modules/terraform-ibm-base-ocp-vpc/issues/159)

---

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### Merge actions for mergers

- Merge by using "Squash and merge".
- Use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents and any release notes provided by the PR author.

    The commit message determines whether a new version of the module is needed, and if so, which semver increment to use (major, minor, or patch).
