### PR TITLE
fix: cluster version region

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -37,7 +37,6 @@ locals {
 # Lookup the current default kube version
 data "ibm_container_cluster_versions" "cluster_versions" {
   resource_group_id = var.resource_group_id
-  region            = var.region
 }
 
 module "cos_instance" {

--- a/main.tf
+++ b/main.tf
@@ -40,7 +40,7 @@ data "ibm_container_cluster_versions" "cluster_versions" {
 }
 
 module "cos_instance" {
-  count = var.use_existing_cos ? 0 : 1
+  count              = var.use_existing_cos ? 0 : 1
   source             = "git::https://github.com/terraform-ibm-modules/terraform-ibm-cos.git?ref=v6.1.0"
   cos_instance_name  = local.cos_name
   resource_group_id  = var.resource_group_id

--- a/main.tf
+++ b/main.tf
@@ -41,7 +41,6 @@ data "ibm_container_cluster_versions" "cluster_versions" {
 
 module "cos_instance" {
   count = var.use_existing_cos ? 0 : 1
-
   source             = "git::https://github.com/terraform-ibm-modules/terraform-ibm-cos.git?ref=v6.1.0"
   cos_instance_name  = local.cos_name
   resource_group_id  = var.resource_group_id

--- a/module-metadata.json
+++ b/module-metadata.json
@@ -175,15 +175,10 @@
       "type": "string",
       "description": "The IBM Cloud region where the cluster will be provisioned.",
       "required": true,
-      "source": [
-        "data.ibm_container_cluster_versions.cluster_versions.region"
-      ],
       "pos": {
         "filename": "variables.tf",
         "line": 17
-      },
-      "cloud_data_type": "region",
-      "deprecated": "This field is deprecated"
+      }
     },
     "resource_group_id": {
       "name": "resource_group_id",
@@ -380,8 +375,7 @@
         "filename": "outputs.tf",
         "line": 43
       },
-      "type": "string",
-      "cloud_data_type": "region"
+      "type": "string"
     },
     "resource_group_id": {
       "name": "resource_group_id",
@@ -448,7 +442,7 @@
       },
       "pos": {
         "filename": "main.tf",
-        "line": 360
+        "line": 359
       }
     },
     "ibm_container_vpc_cluster.autoscaling_cluster": {
@@ -471,7 +465,7 @@
       },
       "pos": {
         "filename": "main.tf",
-        "line": 133
+        "line": 132
       }
     },
     "ibm_container_vpc_cluster.cluster": {
@@ -494,7 +488,7 @@
       },
       "pos": {
         "filename": "main.tf",
-        "line": 71
+        "line": 70
       }
     },
     "ibm_container_vpc_worker_pool.autoscaling_pool": {
@@ -510,7 +504,7 @@
       },
       "pos": {
         "filename": "main.tf",
-        "line": 284
+        "line": 283
       }
     },
     "ibm_container_vpc_worker_pool.pool": {
@@ -526,7 +520,7 @@
       },
       "pos": {
         "filename": "main.tf",
-        "line": 243
+        "line": 242
       }
     },
     "ibm_resource_tag.cluster_access_tag": {
@@ -543,7 +537,7 @@
       },
       "pos": {
         "filename": "main.tf",
-        "line": 197
+        "line": 196
       }
     },
     "ibm_resource_tag.cos_access_tag": {
@@ -559,7 +553,7 @@
       },
       "pos": {
         "filename": "main.tf",
-        "line": 60
+        "line": 59
       }
     },
     "kubernetes_config_map_v1_data.set_autoscaling": {
@@ -574,7 +568,7 @@
       },
       "pos": {
         "filename": "main.tf",
-        "line": 397
+        "line": 396
       }
     },
     "null_resource.confirm_network_healthy": {
@@ -589,7 +583,7 @@
       },
       "pos": {
         "filename": "main.tf",
-        "line": 344
+        "line": 343
       }
     },
     "null_resource.reset_api_key": {
@@ -601,7 +595,7 @@
       },
       "pos": {
         "filename": "main.tf",
-        "line": 218
+        "line": 217
       }
     },
     "time_sleep.wait_operators": {
@@ -613,7 +607,7 @@
       },
       "pos": {
         "filename": "main.tf",
-        "line": 379
+        "line": 378
       }
     }
   },
@@ -631,7 +625,7 @@
       },
       "pos": {
         "filename": "main.tf",
-        "line": 232
+        "line": 231
       }
     },
     "data.ibm_container_cluster_versions.cluster_versions": {
@@ -639,7 +633,6 @@
       "type": "ibm_container_cluster_versions",
       "name": "cluster_versions",
       "attributes": {
-        "region": "region",
         "resource_group_id": "resource_group_id"
       },
       "provider": {
@@ -855,7 +848,7 @@
       },
       "pos": {
         "filename": "main.tf",
-        "line": 43
+        "line": 42
       }
     }
   }

--- a/module-metadata.json
+++ b/module-metadata.json
@@ -442,7 +442,7 @@
       },
       "pos": {
         "filename": "main.tf",
-        "line": 359
+        "line": 358
       }
     },
     "ibm_container_vpc_cluster.autoscaling_cluster": {
@@ -465,7 +465,7 @@
       },
       "pos": {
         "filename": "main.tf",
-        "line": 132
+        "line": 131
       }
     },
     "ibm_container_vpc_cluster.cluster": {
@@ -488,7 +488,7 @@
       },
       "pos": {
         "filename": "main.tf",
-        "line": 70
+        "line": 69
       }
     },
     "ibm_container_vpc_worker_pool.autoscaling_pool": {
@@ -504,7 +504,7 @@
       },
       "pos": {
         "filename": "main.tf",
-        "line": 283
+        "line": 282
       }
     },
     "ibm_container_vpc_worker_pool.pool": {
@@ -520,7 +520,7 @@
       },
       "pos": {
         "filename": "main.tf",
-        "line": 242
+        "line": 241
       }
     },
     "ibm_resource_tag.cluster_access_tag": {
@@ -537,7 +537,7 @@
       },
       "pos": {
         "filename": "main.tf",
-        "line": 196
+        "line": 195
       }
     },
     "ibm_resource_tag.cos_access_tag": {
@@ -553,7 +553,7 @@
       },
       "pos": {
         "filename": "main.tf",
-        "line": 59
+        "line": 58
       }
     },
     "kubernetes_config_map_v1_data.set_autoscaling": {
@@ -568,7 +568,7 @@
       },
       "pos": {
         "filename": "main.tf",
-        "line": 396
+        "line": 395
       }
     },
     "null_resource.confirm_network_healthy": {
@@ -583,7 +583,7 @@
       },
       "pos": {
         "filename": "main.tf",
-        "line": 343
+        "line": 342
       }
     },
     "null_resource.reset_api_key": {
@@ -595,7 +595,7 @@
       },
       "pos": {
         "filename": "main.tf",
-        "line": 217
+        "line": 216
       }
     },
     "time_sleep.wait_operators": {
@@ -607,7 +607,7 @@
       },
       "pos": {
         "filename": "main.tf",
-        "line": 378
+        "line": 377
       }
     }
   },
@@ -625,7 +625,7 @@
       },
       "pos": {
         "filename": "main.tf",
-        "line": 231
+        "line": 230
       }
     },
     "data.ibm_container_cluster_versions.cluster_versions": {


### PR DESCRIPTION
### Description

In terraform-ibm-base-ocp-vpc the block data.ibm_container_cluster_versions region is now deprecated. 

https://github.ibm.com/GoldenEye/issues/issues/4969

### Types of changes in this PR

#### Changes that affect the core Terraform module or submodules
- [x] Bug fix
- [ ] New feature
- [ ] Dependency update

#### Changes that don't affect the core Terraform module or submodules
- [ ] Examples or tests (addition or updates of examples or tests)
- [ ] Documentation update
- [ ] CI-related update (pipeline, etc.)
- [ ] Other

#### Release required?
Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning).

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

The region from the data block ibm_container_cluster_versions has been removed since it was deprecated. As per the provider doc if the region is not specified it will be defaulted to the provider region.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module.

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### Merge actions for mergers

- Use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents and any release notes provided by the PR author. The commit message determines whether a new version of the module is needed, and if so, which semver increment to use (major, minor, or patch).
- Merge by using "Squash and merge".
