### PR TITLE
feat: add support to use  default ocp version

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Optionally, you need the following permissions to attach Access Management tags 
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0, < 1.6.0 |
 | <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | >= 1.58.1, < 2.0.0 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.16.1 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 3.2.1 |

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ Optionally, you need the following permissions to attach Access Management tags 
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
-| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | >= 1.56.1, < 2.0.0 |
+| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | >= 1.58.0, < 2.0.0 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.16.1 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 3.2.1 |
 | <a name="requirement_time"></a> [time](#requirement\_time) | >= 0.9.1 |

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ Optionally, you need the following permissions to attach Access Management tags 
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
-| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | >= 1.58.0, < 2.0.0 |
+| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | >= 1.58.1, < 2.0.0 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.16.1 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 3.2.1 |
 | <a name="requirement_time"></a> [time](#requirement\_time) | >= 0.9.1 |

--- a/examples/add_rules_to_sg/version.tf
+++ b/examples/add_rules_to_sg/version.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     ibm = {
       source  = "ibm-cloud/ibm"
-      version = ">= 1.56.1"
+      version = ">= 1.58.0"
     }
   }
 }

--- a/examples/add_rules_to_sg/version.tf
+++ b/examples/add_rules_to_sg/version.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     ibm = {
       source  = "ibm-cloud/ibm"
-      version = ">= 1.58.0"
+      version = ">= 1.58.1"
     }
   }
 }

--- a/examples/apply_taints/version.tf
+++ b/examples/apply_taints/version.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">=1.3.0"
+  required_version = ">= 1.3.0, < 1.6.0"
   required_providers {
     ibm = {
       source  = "ibm-cloud/ibm"

--- a/examples/apply_taints/version.tf
+++ b/examples/apply_taints/version.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     ibm = {
       source  = "ibm-cloud/ibm"
-      version = ">= 1.56.1"
+      version = ">= 1.58.0"
     }
   }
 }

--- a/examples/apply_taints/version.tf
+++ b/examples/apply_taints/version.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     ibm = {
       source  = "ibm-cloud/ibm"
-      version = ">= 1.58.0"
+      version = ">= 1.58.1"
     }
   }
 }

--- a/examples/existing_cos/version.tf
+++ b/examples/existing_cos/version.tf
@@ -4,7 +4,7 @@ terraform {
     # Pin to the lowest provider version of the range defined in the main module to ensure lowest version still works
     ibm = {
       source  = "ibm-cloud/ibm"
-      version = ">= 1.58.0"
+      version = ">= 1.58.1"
     }
   }
 }

--- a/examples/existing_cos/version.tf
+++ b/examples/existing_cos/version.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.3.0"
+  required_version = ">= 1.3.0, < 1.6.0"
   required_providers {
     # Pin to the lowest provider version of the range defined in the main module to ensure lowest version still works
     ibm = {

--- a/examples/existing_cos/version.tf
+++ b/examples/existing_cos/version.tf
@@ -4,7 +4,7 @@ terraform {
     # Pin to the lowest provider version of the range defined in the main module to ensure lowest version still works
     ibm = {
       source  = "ibm-cloud/ibm"
-      version = ">= 1.56.1"
+      version = ">= 1.58.0"
     }
   }
 }

--- a/examples/fscloud/version.tf
+++ b/examples/fscloud/version.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.3.0"
+  required_version = ">= 1.3.0, < 1.6.0"
   required_providers {
     # Pin to the lowest provider version of the range defined in the main module to ensure lowest version still works
     ibm = {

--- a/examples/fscloud/version.tf
+++ b/examples/fscloud/version.tf
@@ -4,7 +4,7 @@ terraform {
     # Pin to the lowest provider version of the range defined in the main module to ensure lowest version still works
     ibm = {
       source  = "ibm-cloud/ibm"
-      version = "1.56.1"
+      version = "1.58.0"
     }
     # The logdna provider is not actually required by the module itself, just this example, so OK to use ">=" here instead of locking into a version
     logdna = {

--- a/examples/fscloud/version.tf
+++ b/examples/fscloud/version.tf
@@ -4,7 +4,7 @@ terraform {
     # Pin to the lowest provider version of the range defined in the main module to ensure lowest version still works
     ibm = {
       source  = "ibm-cloud/ibm"
-      version = "1.58.0"
+      version = "1.58.1"
     }
     # The logdna provider is not actually required by the module itself, just this example, so OK to use ">=" here instead of locking into a version
     logdna = {

--- a/examples/multiple_mzr_clusters/version.tf
+++ b/examples/multiple_mzr_clusters/version.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     ibm = {
       source  = "ibm-cloud/ibm"
-      version = ">= 1.58.0"
+      version = ">= 1.58.1"
     }
     # The kubernetes provider is not actually required by the module itself, just this example, so OK to use ">=" here instead of locking into a version
     kubernetes = {

--- a/examples/multiple_mzr_clusters/version.tf
+++ b/examples/multiple_mzr_clusters/version.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     ibm = {
       source  = "ibm-cloud/ibm"
-      version = ">= 1.56.1"
+      version = ">= 1.58.0"
     }
     # The kubernetes provider is not actually required by the module itself, just this example, so OK to use ">=" here instead of locking into a version
     kubernetes = {

--- a/examples/multiple_mzr_clusters/version.tf
+++ b/examples/multiple_mzr_clusters/version.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.3.0"
+  required_version = ">= 1.3.0, < 1.6.0"
   required_providers {
     ibm = {
       source  = "ibm-cloud/ibm"

--- a/examples/single_zone_autoscale_cluster/version.tf
+++ b/examples/single_zone_autoscale_cluster/version.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">=1.3.0"
+  required_version = ">= 1.3.0, < 1.6.0"
   required_providers {
     ibm = {
       source  = "ibm-cloud/ibm"

--- a/examples/single_zone_autoscale_cluster/version.tf
+++ b/examples/single_zone_autoscale_cluster/version.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     ibm = {
       source  = "ibm-cloud/ibm"
-      version = ">= 1.56.1"
+      version = ">= 1.58.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/examples/single_zone_autoscale_cluster/version.tf
+++ b/examples/single_zone_autoscale_cluster/version.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     ibm = {
       source  = "ibm-cloud/ibm"
-      version = ">= 1.58.0"
+      version = ">= 1.58.1"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/examples/standard/version.tf
+++ b/examples/standard/version.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     ibm = {
       source  = "ibm-cloud/ibm"
-      version = "1.56.1"
+      version = "1.58.0"
     }
   }
 }

--- a/examples/standard/version.tf
+++ b/examples/standard/version.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">=1.3.0"
+  required_version = ">= 1.3.0, < 1.6.0"
   required_providers {
     ibm = {
       source  = "ibm-cloud/ibm"

--- a/examples/standard/version.tf
+++ b/examples/standard/version.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     ibm = {
       source  = "ibm-cloud/ibm"
-      version = "1.58.0"
+      version = "1.58.1"
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -11,7 +11,7 @@ locals {
   other_autoscaling_pools = [for pool in var.worker_pools : pool if pool.pool_name != "default" && var.ignore_worker_pool_size_changes]
 
   latest_kube_version  = "${data.ibm_container_cluster_versions.cluster_versions.valid_openshift_versions[length(data.ibm_container_cluster_versions.cluster_versions.valid_openshift_versions) - 1]}_openshift"
-  default_kube_version = "${data.ibm_container_cluster_versions.cluster_versions.default_kube_version}_openshift"
+  default_kube_version = "${data.ibm_container_cluster_versions.cluster_versions.default_openshift_version}_openshift"
   kube_version         = var.ocp_version == null || var.ocp_version == "default" ? local.default_kube_version : (var.ocp_version == "latest" ? local.latest_kube_version : "${var.ocp_version}_openshift")
 
   cos_name         = var.use_existing_cos == true || (var.use_existing_cos == false && var.cos_name != null) ? var.cos_name : "${var.cluster_name}_cos"

--- a/main.tf
+++ b/main.tf
@@ -10,9 +10,9 @@ locals {
   other_pools             = [for pool in var.worker_pools : pool if pool.pool_name != "default" && !var.ignore_worker_pool_size_changes]
   other_autoscaling_pools = [for pool in var.worker_pools : pool if pool.pool_name != "default" && var.ignore_worker_pool_size_changes]
 
-  latest_kube_version  = "${data.ibm_container_cluster_versions.cluster_versions.valid_openshift_versions[length(data.ibm_container_cluster_versions.cluster_versions.valid_openshift_versions) - 1]}_openshift"
-  default_kube_version = "${data.ibm_container_cluster_versions.cluster_versions.default_openshift_version}_openshift"
-  kube_version         = var.ocp_version == null || var.ocp_version == "default" ? local.default_kube_version : (var.ocp_version == "latest" ? local.latest_kube_version : "${var.ocp_version}_openshift")
+  latest_ocp_version  = "${data.ibm_container_cluster_versions.cluster_versions.valid_openshift_versions[length(data.ibm_container_cluster_versions.cluster_versions.valid_openshift_versions) - 1]}_openshift"
+  default_ocp_version = "${data.ibm_container_cluster_versions.cluster_versions.default_openshift_version}_openshift"
+  ocp_version         = var.ocp_version == null || var.ocp_version == "default" ? local.default_ocp_version : (var.ocp_version == "latest" ? local.latest_ocp_version : "${var.ocp_version}_openshift")
 
   cos_name         = var.use_existing_cos == true || (var.use_existing_cos == false && var.cos_name != null) ? var.cos_name : "${var.cluster_name}_cos"
   cos_location     = "global"
@@ -75,7 +75,7 @@ resource "ibm_container_vpc_cluster" "cluster" {
   name                            = var.cluster_name
   vpc_id                          = var.vpc_id
   tags                            = var.tags
-  kube_version                    = local.kube_version
+  kube_version                    = local.ocp_version
   flavor                          = local.default_pool.machine_type
   entitlement                     = var.ocp_entitlement
   cos_instance_crn                = local.cos_instance_crn
@@ -136,7 +136,7 @@ resource "ibm_container_vpc_cluster" "autoscaling_cluster" {
   name                            = var.cluster_name
   vpc_id                          = var.vpc_id
   tags                            = var.tags
-  kube_version                    = local.kube_version
+  kube_version                    = local.ocp_version
   flavor                          = local.default_pool.machine_type
   entitlement                     = var.ocp_entitlement
   cos_instance_crn                = local.cos_instance_crn

--- a/main.tf
+++ b/main.tf
@@ -10,8 +10,9 @@ locals {
   other_pools             = [for pool in var.worker_pools : pool if pool.pool_name != "default" && !var.ignore_worker_pool_size_changes]
   other_autoscaling_pools = [for pool in var.worker_pools : pool if pool.pool_name != "default" && var.ignore_worker_pool_size_changes]
 
-  latest_kube_version = "${data.ibm_container_cluster_versions.cluster_versions.valid_openshift_versions[length(data.ibm_container_cluster_versions.cluster_versions.valid_openshift_versions) - 1]}_openshift"
-  kube_version        = var.ocp_version == null || var.ocp_version == "latest" ? local.latest_kube_version : "${var.ocp_version}_openshift"
+  latest_kube_version  = "${data.ibm_container_cluster_versions.cluster_versions.valid_openshift_versions[length(data.ibm_container_cluster_versions.cluster_versions.valid_openshift_versions) - 1]}_openshift"
+  default_kube_version = "${data.ibm_container_cluster_versions.cluster_versions.default_kube_version}_openshift"
+  kube_version         = var.ocp_version == null || var.ocp_version == "default" ? local.default_kube_version : (var.ocp_version == "latest" ? local.latest_kube_version : "${var.ocp_version}_openshift")
 
   cos_name         = var.use_existing_cos == true || (var.use_existing_cos == false && var.cos_name != null) ? var.cos_name : "${var.cluster_name}_cos"
   cos_location     = "global"

--- a/module-metadata.json
+++ b/module-metadata.json
@@ -409,7 +409,7 @@
     "ibm": {
       "source": "ibm-cloud/ibm",
       "version_constraints": [
-        "\u003e= 1.58.0, \u003c 2.0.0"
+        "\u003e= 1.58.1, \u003c 2.0.0"
       ]
     },
     "kubernetes": {

--- a/module-metadata.json
+++ b/module-metadata.json
@@ -403,7 +403,7 @@
     }
   },
   "required_core": [
-    "\u003e= 1.3.0"
+    "\u003e= 1.3.0, \u003c 1.6.0"
   ],
   "required_providers": {
     "ibm": {

--- a/module-metadata.json
+++ b/module-metadata.json
@@ -13,7 +13,7 @@
       ],
       "pos": {
         "filename": "variables.tf",
-        "line": 176
+        "line": 177
       },
       "min_length": 1,
       "max_length": 128,
@@ -29,7 +29,7 @@
       "description": "List of all addons supported by the ocp cluster.",
       "pos": {
         "filename": "variables.tf",
-        "line": 201
+        "line": 202
       }
     },
     "cluster_name": {
@@ -58,7 +58,7 @@
       ],
       "pos": {
         "filename": "variables.tf",
-        "line": 120
+        "line": 121
       }
     },
     "cos_name": {
@@ -67,7 +67,7 @@
       "description": "Name of the COS instance to provision. New instance only provisioned if `use_existing_cos = false`. Default: `\u003ccluster_name\u003e_cos`",
       "pos": {
         "filename": "variables.tf",
-        "line": 148
+        "line": 149
       }
     },
     "disable_public_endpoint": {
@@ -82,7 +82,7 @@
       ],
       "pos": {
         "filename": "variables.tf",
-        "line": 130
+        "line": 131
       }
     },
     "existing_cos_id": {
@@ -91,7 +91,7 @@
       "description": "The COS id of an already existing COS instance. Only required if 'use_existing_cos = true'",
       "pos": {
         "filename": "variables.tf",
-        "line": 160
+        "line": 161
       }
     },
     "force_delete_storage": {
@@ -105,7 +105,7 @@
       ],
       "pos": {
         "filename": "variables.tf",
-        "line": 142
+        "line": 143
       }
     },
     "ibmcloud_api_key": {
@@ -144,7 +144,7 @@
       "description": "Use to attach a Key Protect instance to the cluster",
       "pos": {
         "filename": "variables.tf",
-        "line": 166
+        "line": 167
       }
     },
     "ocp_entitlement": {
@@ -158,7 +158,7 @@
       ],
       "pos": {
         "filename": "variables.tf",
-        "line": 136
+        "line": 137
       }
     },
     "ocp_version": {
@@ -238,7 +238,7 @@
       ],
       "pos": {
         "filename": "variables.tf",
-        "line": 154
+        "line": 155
       }
     },
     "verify_worker_network_readiness": {
@@ -252,7 +252,7 @@
       ],
       "pos": {
         "filename": "variables.tf",
-        "line": 195
+        "line": 196
       }
     },
     "vpc_id": {
@@ -268,7 +268,7 @@
       ],
       "pos": {
         "filename": "variables.tf",
-        "line": 190
+        "line": 191
       },
       "immutable": true
     },
@@ -409,7 +409,7 @@
     "ibm": {
       "source": "ibm-cloud/ibm",
       "version_constraints": [
-        "\u003e= 1.56.1, \u003c 2.0.0"
+        "\u003e= 1.58.0, \u003c 2.0.0"
       ]
     },
     "kubernetes": {
@@ -444,7 +444,7 @@
       },
       "pos": {
         "filename": "main.tf",
-        "line": 363
+        "line": 364
       }
     },
     "ibm_container_vpc_cluster.autoscaling_cluster": {
@@ -467,7 +467,7 @@
       },
       "pos": {
         "filename": "main.tf",
-        "line": 133
+        "line": 134
       }
     },
     "ibm_container_vpc_cluster.cluster": {
@@ -490,7 +490,7 @@
       },
       "pos": {
         "filename": "main.tf",
-        "line": 71
+        "line": 72
       }
     },
     "ibm_container_vpc_worker_pool.autoscaling_pool": {
@@ -506,7 +506,7 @@
       },
       "pos": {
         "filename": "main.tf",
-        "line": 284
+        "line": 285
       }
     },
     "ibm_container_vpc_worker_pool.pool": {
@@ -522,7 +522,7 @@
       },
       "pos": {
         "filename": "main.tf",
-        "line": 243
+        "line": 244
       }
     },
     "ibm_resource_tag.cluster_access_tag": {
@@ -539,7 +539,7 @@
       },
       "pos": {
         "filename": "main.tf",
-        "line": 197
+        "line": 198
       }
     },
     "ibm_resource_tag.cos_access_tag": {
@@ -555,7 +555,7 @@
       },
       "pos": {
         "filename": "main.tf",
-        "line": 60
+        "line": 61
       }
     },
     "kubernetes_config_map_v1_data.set_autoscaling": {
@@ -570,7 +570,7 @@
       },
       "pos": {
         "filename": "main.tf",
-        "line": 404
+        "line": 405
       }
     },
     "null_resource.confirm_network_healthy": {
@@ -585,7 +585,7 @@
       },
       "pos": {
         "filename": "main.tf",
-        "line": 344
+        "line": 345
       }
     },
     "null_resource.reset_api_key": {
@@ -597,7 +597,7 @@
       },
       "pos": {
         "filename": "main.tf",
-        "line": 218
+        "line": 219
       }
     },
     "time_sleep.wait_operators": {
@@ -609,7 +609,7 @@
       },
       "pos": {
         "filename": "main.tf",
-        "line": 386
+        "line": 387
       }
     }
   },
@@ -627,7 +627,7 @@
       },
       "pos": {
         "filename": "main.tf",
-        "line": 232
+        "line": 233
       }
     },
     "data.ibm_container_cluster_versions.cluster_versions": {
@@ -642,7 +642,7 @@
       },
       "pos": {
         "filename": "main.tf",
-        "line": 38
+        "line": 39
       }
     }
   },
@@ -904,7 +904,7 @@
       },
       "pos": {
         "filename": "main.tf",
-        "line": 42
+        "line": 43
       }
     }
   }

--- a/modules/fscloud/README.md
+++ b/modules/fscloud/README.md
@@ -12,7 +12,7 @@ It has been scanned by [IBM Code Risk Analyzer (CRA)](https://cloud.ibm.com/docs
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0, < 1.6.0 |
 
 ### Modules
 

--- a/modules/fscloud/version.tf
+++ b/modules/fscloud/version.tf
@@ -2,5 +2,5 @@
 # Terraform Version
 ##############################################################################
 terraform {
-  required_version = ">= 1.3.0"
+  required_version = ">= 1.3.0, < 1.6.0"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -107,6 +107,7 @@ variable "ocp_version" {
   validation {
     condition = anytrue([
       var.ocp_version == null,
+      var.ocp_version == "default",
       var.ocp_version == "latest",
       var.ocp_version == "4.10",
       var.ocp_version == "4.11",

--- a/version.tf
+++ b/version.tf
@@ -4,7 +4,7 @@ terraform {
     # Use "greater than or equal to" range in modules
     ibm = {
       source  = "ibm-cloud/ibm"
-      version = ">= 1.58.0, < 2.0.0"
+      version = ">= 1.58.1, < 2.0.0"
     }
     null = {
       source  = "hashicorp/null"

--- a/version.tf
+++ b/version.tf
@@ -4,7 +4,7 @@ terraform {
     # Use "greater than or equal to" range in modules
     ibm = {
       source  = "ibm-cloud/ibm"
-      version = ">= 1.56.1, < 2.0.0"
+      version = ">= 1.58.0, < 2.0.0"
     }
     null = {
       source  = "hashicorp/null"

--- a/version.tf
+++ b/version.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.3.0"
+  required_version = ">= 1.3.0, < 1.6.0"
   required_providers {
     # Use "greater than or equal to" range in modules
     ibm = {


### PR DESCRIPTION
### Description

add support for default ocp version

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### Merge actions for mergers

- When merging, use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents and any release notes provided by the PR author. The commit message determines whether a new version of the module is needed, and if so, which semver increment to use (major, minor, or patch).
- Merge by using "Squash and merge".
