### PR TITLE
fix: limit the terraform version

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Optionally, you need the following permissions to attach Access Management tags 
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0, < 1.6.0 |
 | <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | >= 1.56.1, < 2.0.0 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.16.1 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 3.2.1 |

--- a/examples/add_rules_to_sg/version.tf
+++ b/examples/add_rules_to_sg/version.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">=1.3.0"
+  required_version = ">=1.3.0, < 1.6.0"
   required_providers {
     ibm = {
       source  = "ibm-cloud/ibm"

--- a/examples/apply_taints/version.tf
+++ b/examples/apply_taints/version.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">=1.3.0"
+  required_version = ">=1.3.0, < 1.6.0"
   required_providers {
     ibm = {
       source  = "ibm-cloud/ibm"

--- a/examples/existing_cos/version.tf
+++ b/examples/existing_cos/version.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.3.0"
+  required_version = ">= 1.3.0, < 1.6.0"
   required_providers {
     # Pin to the lowest provider version of the range defined in the main module to ensure lowest version still works
     ibm = {

--- a/examples/fscloud/version.tf
+++ b/examples/fscloud/version.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.3.0"
+  required_version = ">= 1.3.0, < 1.6.0"
   required_providers {
     # Pin to the lowest provider version of the range defined in the main module to ensure lowest version still works
     ibm = {

--- a/examples/multiple_mzr_clusters/version.tf
+++ b/examples/multiple_mzr_clusters/version.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.3.0"
+  required_version = ">= 1.3.0, < 1.6.0"
   required_providers {
     ibm = {
       source  = "ibm-cloud/ibm"

--- a/examples/single_zone_autoscale_cluster/version.tf
+++ b/examples/single_zone_autoscale_cluster/version.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">=1.3.0"
+  required_version = ">=1.3.0, < 1.6.0"
   required_providers {
     ibm = {
       source  = "ibm-cloud/ibm"

--- a/examples/standard/version.tf
+++ b/examples/standard/version.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">=1.3.0"
+  required_version = ">=1.3.0, < 1.6.0"
   required_providers {
     ibm = {
       source  = "ibm-cloud/ibm"

--- a/main.tf
+++ b/main.tf
@@ -25,7 +25,7 @@ locals {
   validate_check = regex("^${local.validate_msg}$", (!local.validate_condition ? local.validate_msg : ""))
 
   addons_list = var.addons != null ? { for k, v in var.addons : k => v if v != null } : {}
-  addons      = lookup(local.addons_list, "vpc-block-csi-driver", null) == null ? merge(local.addons_list, { vpc-block-csi-driver = "5.0" }) : local.addons_list
+  addons      = lookup(local.addons_list, "vpc-block-csi-driver", null) == null ? merge(local.addons_list, { vpc-block-csi-driver = "5.2" }) : local.addons_list
 
   delete_timeout = "2h"
   create_timeout = "3h"

--- a/main.tf
+++ b/main.tf
@@ -25,7 +25,7 @@ locals {
   validate_check = regex("^${local.validate_msg}$", (!local.validate_condition ? local.validate_msg : ""))
 
   addons_list = var.addons != null ? { for k, v in var.addons : k => v if v != null } : {}
-  addons      = lookup(local.addons_list, "vpc-block-csi-driver", null) == null ? merge(local.addons_list, { vpc-block-csi-driver = "5.2" }) : local.addons_list
+  addons      = lookup(local.addons_list, "vpc-block-csi-driver", null) == null ? merge(local.addons_list, { vpc-block-csi-driver = "5.1" }) : local.addons_list
 
   delete_timeout = "2h"
   create_timeout = "3h"

--- a/module-metadata.json
+++ b/module-metadata.json
@@ -403,7 +403,7 @@
     }
   },
   "required_core": [
-    "\u003e= 1.3.0"
+    "\u003e= 1.3.0, \u003c 1.6.0"
   ],
   "required_providers": {
     "ibm": {

--- a/modules/fscloud/README.md
+++ b/modules/fscloud/README.md
@@ -12,7 +12,7 @@ It has been scanned by [IBM Code Risk Analyzer (CRA)](https://cloud.ibm.com/docs
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0, < 1.6.0 |
 
 ### Modules
 

--- a/modules/fscloud/version.tf
+++ b/modules/fscloud/version.tf
@@ -2,5 +2,5 @@
 # Terraform Version
 ##############################################################################
 terraform {
-  required_version = ">= 1.3.0"
+  required_version = ">= 1.3.0, < 1.6.0"
 }

--- a/version.tf
+++ b/version.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.3.0"
+  required_version = ">= 1.3.0, < 1.6.0"
   required_providers {
     # Use "greater than or equal to" range in modules
     ibm = {


### PR DESCRIPTION
### Description

<!--- Replace this text with a summary of the changes in this PR. Include why the changes are needed and context about the changes. List required dependencies. If there is a Git issue for the change, please link to it. --->

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

Update the version of the csi-driver and set a upper limit on the terraform version.

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### Merge actions for mergers

- When merging, use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents and any release notes provided by the PR author. The commit message determines whether a new version of the module is needed, and if so, which semver increment to use (major, minor, or patch).
- Merge by using "Squash and merge".
