### PR TITLE
feat: add support for OCP 4.14

### DIFF
--- a/tests/other_test.go
+++ b/tests/other_test.go
@@ -92,6 +92,7 @@ func TestCrossKmsSupportExample(t *testing.T) {
 			"kms_instance_guid":    permanentResources["kp_us_south_guid"],
 			"kms_key_id":           permanentResources["kp_us_south_root_key_id"],
 			"kms_cross_account_id": permanentResources["ge_ops_account_id"],
+			"ocp_version":          ocpVersion2,
 		},
 	})
 

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -23,9 +23,9 @@ const crossKmsSupportExampleDir = "examples/cross_kms_support"
 const yamlLocation = "../common-dev-assets/common-go-assets/common-permanent-resources.yaml"
 
 // Ensure there is one test per supported OCP version
-const ocpVersion1 = "4.13" // used by TestRunUpgradeAdvancedExample, TestFSCloudExample and TestRunMultiClusterExample
-const ocpVersion2 = "4.12" // used by TestRunAdvancedExample and TestRunAddRulesToSGExample
-const ocpVersion3 = "4.11" // used by TestRunBasicExample
+const ocpVersion1 = "4.14" // used by TestRunUpgradeAdvancedExample, TestFSCloudExample and TestRunMultiClusterExample
+const ocpVersion2 = "4.13" // used by TestRunAdvancedExample, TestCrossKmsSupportExample and TestRunAddRulesToSGExample
+const ocpVersion3 = "4.12" // used by TestRunBasicExample
 
 var sharedInfoSvc *cloudinfo.CloudInfoService
 var permanentResources map[string]interface{}

--- a/variables.tf
+++ b/variables.tf
@@ -109,9 +109,9 @@ variable "ocp_version" {
       var.ocp_version == null,
       var.ocp_version == "default",
       var.ocp_version == "latest",
-      var.ocp_version == "4.11",
       var.ocp_version == "4.12",
       var.ocp_version == "4.13",
+      var.ocp_version == "4.14",
     ])
     error_message = "The specified ocp_version is not of the valid versions."
   }


### PR DESCRIPTION
### Description

Update OCP related modules to only support the following versions: 4.12, 4.13, 4.14

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
