### PR TITLE
fix: additional security groups for autoscaling worker pools

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -384,6 +384,8 @@ resource "ibm_container_vpc_worker_pool" "autoscaling_pool" {
   kms_instance_id   = each.value.boot_volume_encryption_kms_config == null ? null : each.value.boot_volume_encryption_kms_config.kms_instance_id
   kms_account_id    = each.value.boot_volume_encryption_kms_config == null ? null : each.value.boot_volume_encryption_kms_config.kms_account_id
 
+  security_groups = each.value.additional_security_group_ids
+
   lifecycle {
     ignore_changes = [worker_count]
   }


### PR DESCRIPTION
### Description

Fix [Issue 523](https://github.com/terraform-ibm-modules/terraform-ibm-base-ocp-vpc/issues/523)

### Release required?

- [ ] No release
- [X] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

* fix: additional security groups will be used when creating autoscaled worker pools

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
