### PR TITLE
test: modified implicitdestroy field to avoid errors in pipeline logs

### DIFF
--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -65,7 +65,6 @@ func setupOptions(t *testing.T, prefix string, terraformDir string, ocpVersion s
 			// workaround for the issue https://github.ibm.com/GoldenEye/issues/issues/10743
 			// when the issue is fixed on IKS, so the destruction of default workers pool is correctly managed on provider/clusters service the next two entries should be removed
 			"'module.ocp_base.ibm_container_vpc_worker_pool.autoscaling_pool[\"default\"]'",
-			"'module.ocp_base.ibm_container_vpc_worker_pool.pool[\"default\"]'",
 		},
 	})
 


### PR DESCRIPTION
### Description

This PR attempts to fix the [issue-536](https://github.com/terraform-ibm-modules/terraform-ibm-base-ocp-vpc/issues/536)

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [x] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [x] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
