### PR TITLE
fix: modified retry logic issue

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -460,7 +460,7 @@ resource "null_resource" "confirm_network_healthy" {
 ##############################################################################
 resource "null_resource" "ocp_console_management" {
 
-  depends_on = [ibm_container_vpc_cluster.cluster, ibm_container_vpc_cluster.autoscaling_cluster, ibm_container_vpc_worker_pool.pool, ibm_container_vpc_worker_pool.autoscaling_pool]
+  depends_on = [null_resource.confirm_network_healthy]
   triggers = {
     enable_ocp_console = var.enable_ocp_console
   }

--- a/scripts/enable_disable_ocp_console.sh
+++ b/scripts/enable_disable_ocp_console.sh
@@ -17,7 +17,7 @@ function check_oc_cli() {
 function apply_oc_patch() {
 
   local attempt=0
-  local retry_wait_time=60
+  local retry_wait_time=5
 
   while [ $attempt -lt $MAX_ATTEMPTS ]; do
     echo "Attempt $((attempt+1)) of $MAX_ATTEMPTS: Applying OpenShift Console patch..."
@@ -60,8 +60,8 @@ function remove_oc_patch() {
 
 echo "========================================="
 
-if [[ -z "${ENABLE_OCP_CONSOLE}" ]]; then
-    echo "ENABLE_OCP_CONSOLE must be set" >&2
+if [[ -z "${ENABLE_OCP_CONSOLE:-}" ]]; then
+    echo "ENABLE_OCP_CONSOLE must be set ... exiting." >&2
     exit 1
 fi
 

--- a/scripts/enable_disable_ocp_console.sh
+++ b/scripts/enable_disable_ocp_console.sh
@@ -6,7 +6,6 @@ set -euo pipefail
 PATCH_APPLY="oc patch consoles.operator.openshift.io cluster --patch '{\"spec\":{\"managementState\":\"Managed\"}}' --type=merge"
 PATCH_REMOVE="oc patch consoles.operator.openshift.io cluster --patch '{\"spec\":{\"managementState\":\"Removed\"}}' --type=merge"
 MAX_ATTEMPTS=10
-RETRY_WAIT=5
 
 function check_oc_cli() {
   if ! command -v oc &> /dev/null; then
@@ -18,6 +17,8 @@ function check_oc_cli() {
 function apply_oc_patch() {
 
   local attempt=0
+  local retry_wait_time=60
+
   while [ $attempt -lt $MAX_ATTEMPTS ]; do
     echo "Attempt $((attempt+1)) of $MAX_ATTEMPTS: Applying OpenShift Console patch..."
 
@@ -25,10 +26,9 @@ function apply_oc_patch() {
       echo "Patch applied successfully."
       return 0
     else
-      echo "Failed to apply patch. Retrying in ${RETRY_WAIT}s..."
-      sleep $RETRY_WAIT
+      echo "Failed to apply patch. Retrying in ${retry_wait_time}s..."
+      sleep $retry_wait_time
       ((attempt++))
-      RETRY_WAIT=$((RETRY_WAIT * 2))
     fi
   done
 
@@ -39,6 +39,8 @@ function apply_oc_patch() {
 function remove_oc_patch() {
 
   local attempt=0
+  local retry_wait_time=5
+
   while [ $attempt -lt $MAX_ATTEMPTS ]; do
     echo "Attempt $((attempt+1)) of $MAX_ATTEMPTS: Removing OpenShift Console patch..."
 
@@ -46,10 +48,9 @@ function remove_oc_patch() {
       echo "Patch removed successfully."
       return 0
     else
-      echo "Failed to remove patch. Retrying in ${RETRY_WAIT}s..."
-      sleep $RETRY_WAIT
+      echo "Failed to remove patch. Retrying in ${retry_wait_time}s..."
+      sleep $retry_wait_time
       ((attempt++))
-      RETRY_WAIT=$((RETRY_WAIT * 2))
     fi
   done
 


### PR DESCRIPTION
### Description

Updated the script by removing exponential backoff time and scoping the retry_wait time to respective functions.
Issue - #599

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [x] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
