### PR TITLE
fix: run cluster_config for ocp_console_management

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -299,7 +299,7 @@ resource "null_resource" "reset_api_key" {
 ##############################################################################
 
 data "ibm_container_cluster_config" "cluster_config" {
-  count             = var.verify_worker_network_readiness || lookup(var.addons, "cluster-autoscaler", null) != null ? 1 : 0
+  count             = var.enable_ocp_console || var.verify_worker_network_readiness || lookup(var.addons, "cluster-autoscaler", null) != null ? 1 : 0
   cluster_name_id   = local.cluster_id
   config_dir        = "${path.module}/kubeconfig"
   admin             = true # workaround for https://github.com/terraform-ibm-modules/terraform-ibm-base-ocp-vpc/issues/374


### PR DESCRIPTION
### Description

```
resource "null_resource" "ocp_console_management" {

  depends_on = [null_resource.confirm_network_healthy]
  triggers = {
    enable_ocp_console = var.enable_ocp_console
  }
  provisioner "local-exec" {
    command     = "${path.module}/scripts/enable_disable_ocp_console.sh"
    interpreter = ["/bin/bash", "-c"]
    environment = {
      KUBECONFIG         = data.ibm_container_cluster_config.cluster_config[0].config_file_path
      ENABLE_OCP_CONSOLE = var.enable_ocp_console
    }
  }
}
```
The `ocp_console_management` block requires `ibm_container_cluster_config.cluster_config` but it used to only run if network_readiness was set to true of if we were to install cluster_autoscaler. If these condition was false `ibm_container_cluster_config.cluster_config` wouldn't run and it would cause the `ocp_console_management` to fail with the following error.
```
╷
│ Error: Invalid index
│ 
│   on .terraform/modules/landing_zone.landing_zone.cluster/main.tf line 473, in resource "null_resource" "ocp_console_management":
│  473:       KUBECONFIG         = data.ibm_container_cluster_config.cluster_config[0].config_file_path
│     ├────────────────
│     │ data.ibm_container_cluster_config.cluster_config is empty tuple
│ 
│ The given key does not identify an element in this collection value: the collection has no elements.
```

<!--- Replace this text with a summary of the changes in this PR. Include why the changes are needed and context about the changes. List required dependencies. If there is a Git issue for the change, please link to it. --->

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
