### PR TITLE
fix: update latest ibmcloud provider version

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "go.sum|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2025-04-01T10:27:06Z",
+  "generated_at": "2025-05-14T17:28:16Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -82,7 +82,7 @@
         "hashed_secret": "8196b86ede820e665b2b8af9c648f4996be99838",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 60,
+        "line_number": 65,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ Optionally, you need the following permissions to attach Access Management tags 
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9.0 |
-| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | >= 1.71.0, < 2.0.0 |
+| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | >= 1.78.2, < 2.0.0 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.16.1, < 3.0.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 3.2.1, < 4.0.0 |
 
@@ -263,7 +263,6 @@ Optionally, you need the following permissions to attach Access Management tags 
 | [ibm_resource_tag.cos_access_tag](https://registry.terraform.io/providers/ibm-cloud/ibm/latest/docs/resources/resource_tag) | resource |
 | [kubernetes_config_map_v1_data.set_autoscaling](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/config_map_v1_data) | resource |
 | [null_resource.config_map_status](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
-| [null_resource.confirm_lb_active](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [null_resource.confirm_network_healthy](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [null_resource.ocp_console_management](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [null_resource.reset_api_key](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
@@ -273,7 +272,6 @@ Optionally, you need the following permissions to attach Access Management tags 
 | [ibm_container_vpc_worker_pool.all_pools](https://registry.terraform.io/providers/ibm-cloud/ibm/latest/docs/data-sources/container_vpc_worker_pool) | data source |
 | [ibm_iam_account_settings.iam_account_settings](https://registry.terraform.io/providers/ibm-cloud/ibm/latest/docs/data-sources/iam_account_settings) | data source |
 | [ibm_iam_auth_token.reset_api_key_tokendata](https://registry.terraform.io/providers/ibm-cloud/ibm/latest/docs/data-sources/iam_auth_token) | data source |
-| [ibm_iam_auth_token.tokendata](https://registry.terraform.io/providers/ibm-cloud/ibm/latest/docs/data-sources/iam_auth_token) | data source |
 | [ibm_is_lbs.all_lbs](https://registry.terraform.io/providers/ibm-cloud/ibm/latest/docs/data-sources/is_lbs) | data source |
 | [ibm_is_virtual_endpoint_gateway.api_vpe](https://registry.terraform.io/providers/ibm-cloud/ibm/latest/docs/data-sources/is_virtual_endpoint_gateway) | data source |
 | [ibm_is_virtual_endpoint_gateway.master_vpe](https://registry.terraform.io/providers/ibm-cloud/ibm/latest/docs/data-sources/is_virtual_endpoint_gateway) | data source |

--- a/examples/add_rules_to_sg/version.tf
+++ b/examples/add_rules_to_sg/version.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = "1.76.0"
+      version = "1.78.2"
     }
   }
 }

--- a/examples/advanced/version.tf
+++ b/examples/advanced/version.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = ">= 1.71.0"
+      version = ">= 1.78.2"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/examples/basic/version.tf
+++ b/examples/basic/version.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = "1.76.0"
+      version = "1.78.2"
     }
   }
 }

--- a/examples/cross_kms_support/version.tf
+++ b/examples/cross_kms_support/version.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = ">= 1.71.0"
+      version = ">= 1.78.2"
     }
   }
 }

--- a/examples/custom_sg/version.tf
+++ b/examples/custom_sg/version.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = ">= 1.71.0"
+      version = ">= 1.78.2"
     }
   }
 }

--- a/examples/fscloud/version.tf
+++ b/examples/fscloud/version.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     ibm = {
       source  = "ibm-cloud/ibm"
-      version = ">= 1.71.0"
+      version = ">= 1.78.2"
     }
   }
 }

--- a/examples/multiple_mzr_clusters/version.tf
+++ b/examples/multiple_mzr_clusters/version.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     ibm = {
       source  = "ibm-cloud/ibm"
-      version = ">= 1.71.0"
+      version = ">= 1.78.2"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/main.tf
+++ b/main.tf
@@ -602,30 +602,7 @@ locals {
   lbs_associated_with_cluster = length(var.additional_lb_security_group_ids) > 0 ? [for lb in data.ibm_is_lbs.all_lbs[0].load_balancers : lb.id if strcontains(lb.name, local.cluster_id)] : []
 }
 
-
-data "ibm_iam_auth_token" "tokendata" {
-  depends_on = [data.ibm_is_lbs.all_lbs]
-}
-
-resource "null_resource" "confirm_lb_active" {
-  count      = length(var.additional_lb_security_group_ids)
-  depends_on = [data.ibm_iam_auth_token.tokendata]
-
-  triggers = {
-    confirm_lb_active = var.additional_lb_security_group_ids[count.index]
-  }
-
-  provisioner "local-exec" {
-    command     = "${path.module}/scripts/confirm_lb_active.sh ${var.region} ${local.lbs_associated_with_cluster[count.index]} ${var.use_private_endpoint}"
-    interpreter = ["/bin/bash", "-c"]
-    environment = {
-      IAM_TOKEN = data.ibm_iam_auth_token.tokendata.iam_access_token
-    }
-  }
-}
-
 module "attach_sg_to_lb" {
-  depends_on                     = [null_resource.confirm_lb_active]
   count                          = length(var.additional_lb_security_group_ids)
   source                         = "terraform-ibm-modules/security-group/ibm"
   version                        = "2.6.2"

--- a/modules/fscloud/README.md
+++ b/modules/fscloud/README.md
@@ -93,7 +93,7 @@ module "ocp_base_fscloud" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9.0 |
-| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | >= 1.71.0, < 2.0.0 |
+| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | >= 1.78.2, < 2.0.0 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.16.1, < 3.0.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 3.2.1, < 4.0.0 |
 | <a name="requirement_time"></a> [time](#requirement\_time) | >= 0.9.1, < 1.0.0 |

--- a/modules/fscloud/version.tf
+++ b/modules/fscloud/version.tf
@@ -12,7 +12,7 @@ terraform {
     # tflint-ignore: terraform_unused_required_providers
     ibm = {
       source  = "ibm-cloud/ibm"
-      version = ">= 1.71.0, < 2.0.0"
+      version = ">= 1.78.2, < 2.0.0"
     }
     # tflint-ignore: terraform_unused_required_providers
     null = {

--- a/modules/kube-audit/README.md
+++ b/modules/kube-audit/README.md
@@ -57,7 +57,7 @@ module "kube_audit" {
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=1.9.0 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.15.0, <3.0.0 |
-| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | >= 1.70.0, <2.0.0 |
+| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | >= 1.78.2, <2.0.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 3.2.1, < 4.0.0 |
 | <a name="requirement_time"></a> [time](#requirement\_time) | >= 0.9.1, < 1.0.0 |
 

--- a/modules/kube-audit/version.tf
+++ b/modules/kube-audit/version.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     ibm = {
       source  = "ibm-cloud/ibm"
-      version = ">= 1.70.0, <2.0.0"
+      version = ">= 1.78.2, <2.0.0"
     }
     null = {
       source  = "hashicorp/null"

--- a/solutions/fully-configurable/README.md
+++ b/solutions/fully-configurable/README.md
@@ -17,7 +17,7 @@ The following resources are provisioned by this example:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=1.9.0 |
-| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | 1.78.0 |
+| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | 1.78.2 |
 
 ### Modules
 
@@ -35,8 +35,8 @@ The following resources are provisioned by this example:
 
 | Name | Type |
 |------|------|
-| [ibm_is_subnet.subnets](https://registry.terraform.io/providers/IBM-Cloud/ibm/1.78.0/docs/data-sources/is_subnet) | data source |
-| [ibm_is_subnets.vpc_subnets](https://registry.terraform.io/providers/IBM-Cloud/ibm/1.78.0/docs/data-sources/is_subnets) | data source |
+| [ibm_is_subnet.subnets](https://registry.terraform.io/providers/IBM-Cloud/ibm/1.78.2/docs/data-sources/is_subnet) | data source |
+| [ibm_is_subnets.vpc_subnets](https://registry.terraform.io/providers/IBM-Cloud/ibm/1.78.2/docs/data-sources/is_subnets) | data source |
 
 ### Inputs
 

--- a/solutions/fully-configurable/version.tf
+++ b/solutions/fully-configurable/version.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = "1.77.1"
+      version = "1.78.2"
     }
   }
 }

--- a/tests/other_test.go
+++ b/tests/other_test.go
@@ -15,12 +15,6 @@ const advancedExampleDir = "examples/advanced"
 const basicExampleDir = "examples/basic"
 const fscloudExampleDir = "examples/fscloud"
 const crossKmsSupportExampleDir = "examples/cross_kms_support"
-const customsgExampleDir = "examples/custom_sg"
-
-// Ensure there is one test per supported OCP version
-const ocpVersion2 = "4.16" // used by TestCustomSGExample and TestRunCustomsgExample
-const ocpVersion3 = "4.15" // used by TestRunAdvancedExample and TestCrossKmsSupportExample
-const ocpVersion4 = "4.14" // used by TestRunAddRulesToSGExample and TestRunBasicExample
 
 func setupOptions(t *testing.T, prefix string, terraformDir string, ocpVersion string) *testhelper.TestOptions {
 	options := testhelper.TestOptionsDefaultWithVars(&testhelper.TestOptions{
@@ -67,17 +61,6 @@ func TestRunBasicExample(t *testing.T) {
 	t.Parallel()
 
 	options := setupOptions(t, "base-ocp", basicExampleDir, ocpVersion4)
-
-	output, err := options.RunTestConsistency()
-
-	assert.Nil(t, err, "This should not have errored")
-	assert.NotNil(t, output, "Expected some output")
-}
-
-func TestRunCustomsgExample(t *testing.T) {
-	t.Parallel()
-
-	options := setupOptions(t, "base-ocp-customsg", customsgExampleDir, ocpVersion2)
 
 	output, err := options.RunTestConsistency()
 
@@ -140,28 +123,6 @@ func TestRunAddRulesToSGExample(t *testing.T) {
 		ImplicitRequired: false,
 		TerraformVars: map[string]interface{}{
 			"ocp_version": ocpVersion4,
-		},
-	})
-	output, err := options.RunTestConsistency()
-	assert.Nil(t, err, "This should not have errored")
-	assert.NotNil(t, output, "Expected some output")
-}
-
-func TestCustomSGExample(t *testing.T) {
-	t.Parallel()
-	options := testhelper.TestOptionsDefaultWithVars(&testhelper.TestOptions{
-		Testing:       t,
-		TerraformDir:  "examples/custom_sg",
-		Prefix:        "cust-sg",
-		ResourceGroup: resourceGroup,
-		ImplicitDestroy: []string{
-			"module.ocp_base.null_resource.confirm_network_healthy",
-			"module.ocp_base.null_resource.reset_api_key",
-		},
-		// Do not hard fail the test if the implicit destroy steps fail to allow a full destroy of resource to occur
-		ImplicitRequired: false,
-		TerraformVars: map[string]interface{}{
-			"ocp_version": ocpVersion2,
 		},
 	})
 	output, err := options.RunTestConsistency()

--- a/version.tf
+++ b/version.tf
@@ -4,7 +4,7 @@ terraform {
     # Use "greater than or equal to" range in modules
     ibm = {
       source  = "ibm-cloud/ibm"
-      version = ">= 1.71.0, < 2.0.0"
+      version = ">= 1.78.2, < 2.0.0"
     }
     null = {
       source  = "hashicorp/null"


### PR DESCRIPTION
### Description

This is an update to the most recent version of the IBM-Cloud Terraform provider which includes a bug fix to the attach of security groups to a load balancer not in "active" state.

As a result of this provider bug fix, the workaround script in this module to also solve this problem has been removed.

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
