### PR TITLE
docs: add IAM requirement for UserApiKeyCreator

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,8 @@ You need the following permissions to run this module.
   - **VPC Infrastructure** service
     - `Administrator` platform access
     - `Manager` service access
+  - **IAM Identity Service** service
+    - `User API key creator` service access
 
 Optionally, you need the following permissions to attach Access Management tags to resources in this module.
 

--- a/ibm_catalog.json
+++ b/ibm_catalog.json
@@ -56,9 +56,11 @@
           "iam_permissions": [
             {
               "role_crns": [
-                "crn:v1:bluemix:public:iam::::role:Administrator"
+                "crn:v1:bluemix:public:iam::::role:Administrator",
+                "crn:v1:bluemix:public:iam-identity::::serviceRole:UserApiKeyCreator"
               ],
-              "service_name": "iam-identity"
+              "service_name": "iam-identity",
+              "notes": "Allows IBM Cloud OpenShift to create the containers-kubernetes-key required by the service"
             },
             {
               "role_crns": [


### PR DESCRIPTION
### Description

Added documentation to make it clear that the `IAM Identity Service -> UserApiKeyCreator` service permission is required for this module to deploy correctly.

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [x] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
