### PR TITLE
refactor: Regex validation

### DIFF
--- a/ibm_catalog.json
+++ b/ibm_catalog.json
@@ -682,11 +682,6 @@
             },
             {
               "key": "kms_endpoint_type",
-              "value_constraint": {
-								"type": "regex",
-								"description": "The kms_endpoint_type value must be 'public' or 'private'.",
-								"value": "public|private"
-							},
               "options": [
                 {
                   "displayname": "Public",

--- a/ibm_catalog.json
+++ b/ibm_catalog.json
@@ -190,7 +190,12 @@
             },
             {
               "key": "prefix",
-              "required": true
+              "required": true,
+              "value_constraint": {
+								"type": "regex",
+								"description": "Prefix must begin with a lowercase letter and may contain only lowercase letters, digits, and hyphens '-'. It must not end with a hyphen('-'), and cannot contain consecutive hyphens ('--'). It should not exceed 16 characters",
+								"value": "^(?:$|[a-z](?!.*--)[a-z0-9-]{0,14}[a-z0-9])$"
+							}
             },
             {
               "key": "cluster_name",
@@ -226,6 +231,11 @@
             {
               "key": "default_worker_pool_machine_type",
               "required": true,
+              "value_constraint": {
+								"type": "regex",
+								"description": "Invalid value provided for the machine type.",
+								"value": "^[a-z0-9]+(?:\\.[a-z0-9]+)*\\.\\d+x\\d+(?:\\.[a-z0-9]+)?$"
+							},
               "options": [
                 {
                   "displayname": "bx2.16x64",
@@ -655,13 +665,28 @@
               "key": "kms_encryption_enabled_cluster"
             },
             {
-              "key": "existing_kms_instance_crn"
+              "key": "existing_kms_instance_crn",
+              "value_constraint": {
+								"type": "regex",
+								"description": "The provided KMS instance CRN in the input 'existing_kms_instance_crn' in not valid.",
+								"value": "^crn:(.*:){3}(kms|hs-crypto):(.*:){2}[0-9a-fA-F]{8}(?:-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12}::$"
+							}
             },
             {
-              "key": "existing_cluster_kms_key_crn"
+              "key": "existing_cluster_kms_key_crn",
+              "value_constraint": {
+								"type": "regex",
+								"description": "The provided KMS key CRN in the input 'existing_cluster_kms_key_crn' in not valid.",
+								"value": "^crn:(.*:){3}(kms|hs-crypto):(.*:){2}[0-9a-fA-F]{8}(?:-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12}:key:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+							}
             },
             {
               "key": "kms_endpoint_type",
+              "value_constraint": {
+								"type": "regex",
+								"description": "The kms_endpoint_type value must be 'public' or 'private'.",
+								"value": "public|private"
+							},
               "options": [
                 {
                   "displayname": "Public",
@@ -684,7 +709,12 @@
               "key": "kms_encryption_enabled_boot_volume"
             },
             {
-              "key": "existing_boot_volume_kms_key_crn"
+              "key": "existing_boot_volume_kms_key_crn",
+              "value_constraint": {
+                "type": "regex",
+                "description": "The provided KMS key CRN in the input 'existing_boot_volume_kms_key_crn' in not valid.",
+                "value": "^crn:(.*:){3}(kms|hs-crypto):(.*:){2}[0-9a-fA-F]{8}(?:-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12}:key:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+              }
             },
             {
               "key": "boot_volume_kms_key_name"
@@ -801,7 +831,12 @@
               "key": "audit_webhook_listener_image"
             },
             {
-              "key": "audit_webhook_listener_image_tag_digest"
+              "key": "audit_webhook_listener_image_tag_digest",
+              "value_constraint": {
+								"type": "regex",
+								"description": "The value of the audit webhook listener image version must match the tag and sha256 image digest format",
+								"value": "^[a-f0-9]{40}@sha256:[a-f0-9]{64}$"
+							}
             }
           ],
           "dependencies": [

--- a/solutions/fully-configurable/variables.tf
+++ b/solutions/fully-configurable/variables.tf
@@ -14,28 +14,7 @@ variable "ibmcloud_api_key" {
 variable "prefix" {
   type        = string
   nullable    = true
-  description = "The prefix to be added to all resources created by this solution. To skip using a prefix, set this value to null or an empty string. The prefix must begin with a lowercase letter and may contain only lowercase letters, digits, and hyphens '-'. It should not exceed 16 characters, must not end with a hyphen('-'), and can not contain consecutive hyphens ('--'). Example: prod-0405-ocp. [Learn more](https://terraform-ibm-modules.github.io/documentation/#/prefix.md)."
-
-  validation {
-    # - null and empty string is allowed
-    # - Must not contain consecutive hyphens (--): length(regexall("--", var.prefix)) == 0
-    # - Starts with a lowercase letter: [a-z]
-    # - Contains only lowercase letters (a–z), digits (0–9), and hyphens (-)
-    # - Must not end with a hyphen (-): [a-z0-9]
-    condition = (var.prefix == null || var.prefix == "" ? true :
-      alltrue([
-        can(regex("^[a-z][-a-z0-9]*[a-z0-9]$", var.prefix)),
-        length(regexall("--", var.prefix)) == 0
-      ])
-    )
-    error_message = "Prefix must begin with a lowercase letter and may contain only lowercase letters, digits, and hyphens '-'. It must not end with a hyphen('-'), and cannot contain consecutive hyphens ('--')."
-  }
-
-  validation {
-    # must not exceed 16 characters in length
-    condition     = var.prefix == null || var.prefix == "" ? true : length(var.prefix) <= 16
-    error_message = "Prefix must not exceed 16 characters."
-  }
+  description = "The prefix to be added to all resources created by this solution. To skip using a prefix, set this value to null or an empty string. Example: prod-0405-ocp. [Learn more](https://terraform-ibm-modules.github.io/documentation/#/prefix.md)."
 }
 
 
@@ -166,10 +145,6 @@ variable "default_worker_pool_machine_type" {
   type        = string
   description = "The machine type for worker nodes.[Learn more](https://cloud.ibm.com/docs/openshift?topic=openshift-vpc-flavors)"
   default     = "bx2.8x32"
-  validation {
-    condition     = length(regexall("^[a-z0-9]+(?:\\.[a-z0-9]+)*\\.\\d+x\\d+(?:\\.[a-z0-9]+)?$", var.default_worker_pool_machine_type)) > 0
-    error_message = "Invalid value provided for the machine type."
-  }
 }
 
 variable "default_worker_pool_workers_per_zone" {
@@ -378,29 +353,12 @@ variable "existing_kms_instance_crn" {
   type        = string
   default     = null
   description = "The CRN of an existing KMS instance (Hyper Protect Crypto Services or Key Protect). If the KMS instance is in different account you must also provide a value for `ibmcloud_kms_api_key`."
-
-  validation {
-    condition = anytrue([
-      can(regex("^crn:(.*:){3}(kms|hs-crypto):(.*:){2}[0-9a-fA-F]{8}(?:-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12}::$", var.existing_kms_instance_crn)),
-      var.existing_kms_instance_crn == null,
-    ])
-    error_message = "The provided KMS instance CRN in the input 'existing_kms_instance_crn' in not valid."
-  }
 }
 
 variable "existing_cluster_kms_key_crn" {
   type        = string
   default     = null
   description = "The CRN of an existing KMS key to use for encrypting the Object Storage of the Cluster. If no value is set for this variable, specify a value for `existing_kms_instance_crn` variable to create a key ring and key."
-
-  validation {
-    condition = anytrue([
-      can(regex("^crn:(.*:){3}(kms|hs-crypto):(.*:){2}[0-9a-fA-F]{8}(?:-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12}:key:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$", var.existing_cluster_kms_key_crn)),
-      var.existing_cluster_kms_key_crn == null,
-    ])
-    error_message = "The provided KMS key CRN in the input 'existing_cluster_kms_key_crn' in not valid."
-  }
-
   validation {
     condition     = var.existing_cluster_kms_key_crn != null ? var.existing_kms_instance_crn == null : true
     error_message = "A value should not be passed for 'existing_kms_instance_crn' when passing an existing key value using the 'existing_cluster_kms_key_crn' input."
@@ -410,13 +368,9 @@ variable "existing_cluster_kms_key_crn" {
 
 variable "kms_endpoint_type" {
   type        = string
-  description = "The endpoint for communicating with the KMS instance. Possible values: `public`, `private`. Applies only if `kms_encryption_enabled_cluster` is true"
+  description = "The endpoint for communicating with the KMS instance. Applies only if `kms_encryption_enabled_cluster` is true"
   default     = "private"
   nullable    = false
-  validation {
-    condition     = can(regex("public|private", var.kms_endpoint_type))
-    error_message = "The kms_endpoint_type value must be 'public' or 'private'."
-  }
 }
 
 variable "cluster_kms_key_ring_name" {
@@ -464,14 +418,6 @@ variable "existing_boot_volume_kms_key_crn" {
   type        = string
   default     = null
   description = "The CRN of an existing KMS key to use to encrypt the the block storage volumes for VPC. If no value is set for this variable, specify a value for either the `existing_kms_instance_crn` variable to create a key ring and key."
-
-  validation {
-    condition = anytrue([
-      can(regex("^crn:(.*:){3}(kms|hs-crypto):(.*:){2}[0-9a-fA-F]{8}(?:-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12}:key:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$", var.existing_boot_volume_kms_key_crn)),
-      var.existing_boot_volume_kms_key_crn == null,
-    ])
-    error_message = "The provided KMS key CRN in the input 'existing_boot_volume_kms_key_crn' in not valid."
-  }
 }
 
 variable "boot_volume_kms_key_ring_name" {
@@ -600,9 +546,4 @@ variable "audit_webhook_listener_image_tag_digest" {
   type        = string
   description = "The tag or digest for the audit webhook listener image to deploy. If changing the value, ensure it is compatible with `audit_webhook_listener_image`."
   default     = "deaabcb8225e800385413ba420cf3f819d3b0671@sha256:acf123f4dba63534cbc104c6886abedff9d25a22a34ab7b549ede988ed6e7144"
-
-  validation {
-    condition     = can(regex("^[a-f0-9]{40}@sha256:[a-f0-9]{64}$", var.audit_webhook_listener_image_tag_digest))
-    error_message = "The value of the audit webhook listener image version must match the tag and sha256 image digest format"
-  }
 }

--- a/solutions/fully-configurable/variables.tf
+++ b/solutions/fully-configurable/variables.tf
@@ -145,6 +145,10 @@ variable "default_worker_pool_machine_type" {
   type        = string
   description = "The machine type for worker nodes.[Learn more](https://cloud.ibm.com/docs/openshift?topic=openshift-vpc-flavors)"
   default     = "bx2.8x32"
+  validation {
+    condition     = length(regexall("^[a-z0-9]+(?:\\.[a-z0-9]+)*\\.\\d+x\\d+(?:\\.[a-z0-9]+)?$", var.default_worker_pool_machine_type)) > 0
+    error_message = "Invalid value provided for the machine type."
+  }
 }
 
 variable "default_worker_pool_workers_per_zone" {
@@ -359,6 +363,7 @@ variable "existing_cluster_kms_key_crn" {
   type        = string
   default     = null
   description = "The CRN of an existing KMS key to use for encrypting the Object Storage of the Cluster. If no value is set for this variable, specify a value for `existing_kms_instance_crn` variable to create a key ring and key."
+
   validation {
     condition     = var.existing_cluster_kms_key_crn != null ? var.existing_kms_instance_crn == null : true
     error_message = "A value should not be passed for 'existing_kms_instance_crn' when passing an existing key value using the 'existing_cluster_kms_key_crn' input."
@@ -368,9 +373,13 @@ variable "existing_cluster_kms_key_crn" {
 
 variable "kms_endpoint_type" {
   type        = string
-  description = "The endpoint for communicating with the KMS instance. Applies only if `kms_encryption_enabled_cluster` is true"
+  description = "The endpoint for communicating with the KMS instance. Possible values: `public`, `private`. Applies only if `kms_encryption_enabled_cluster` is true"
   default     = "private"
   nullable    = false
+  validation {
+    condition     = can(regex("public|private", var.kms_endpoint_type))
+    error_message = "The kms_endpoint_type value must be 'public' or 'private'."
+  }
 }
 
 variable "cluster_kms_key_ring_name" {


### PR DESCRIPTION
### Description
https://github.ibm.com/GoldenEye/issues/issues/15220
<!--- Replace this text with a summary of the changes in this PR. Include why the changes are needed and context about the changes. List required dependencies. If there is a Git issue for the change, please link to it. --->

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [x] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content
This PR uses the new UI regex validation to enforce input rules on the frontend, making validation easier.
<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
